### PR TITLE
Prevent crashes on temporary/partially downloaded files

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -51,7 +51,7 @@ let generateFor (file:FileInfo) =
 let handleWatcherEvents (e:FileSystemEventArgs) =
     let fi = fileInfo e.FullPath 
     traceImportant fi.Name
-    match fi.Attributes.HasFlag FileAttributes.Hidden with
+    match fi.Attributes.HasFlag FileAttributes.Hidden || fi.Attributes.HasFlag FileAttributes.Directory with
             | true -> ()
             | _ -> generateFor fi
 


### PR DESCRIPTION
Fixes #28.

Should not fire `generateFor` if the file is hidden or when the `FileInfo` from the watcher event is a directory. This prevent all the erroneous output and exception traces on every change ('string cannot be of zero length').

Additionally, should handle `FileNotFoundException` is the file disappeared between the event firing and the handling - which is what happens if you download an image using Chrome (creates a temp crdownload file).
