### PR TITLE
Fix for multiline speaker notes

### DIFF
--- a/src/FsReveal/Formatting.fs
+++ b/src/FsReveal/Formatting.fs
@@ -6,10 +6,20 @@ open System.Text
 open System.IO
 open System
 
-let replaceSpeakerNotes (text : string []) = 
-    text |> Array.map (fun line -> 
-                if line.StartsWith("' ") then "<aside class=\"notes\">" + line.Substring(2) + "</aside>"
-                else line)
+let (|SpeakerNote|OtherLine|) (line : string) =
+    if line.StartsWith("' ") then SpeakerNote (line.Substring(2) + "<br/>")
+    else OtherLine line
+
+let replaceSpeakerNotes text =
+    let rec loop inNotes = function
+        | (SpeakerNote note) :: lines -> 
+            if inNotes then note::(loop true lines)
+            else "<aside class=\"notes\">"::note::(loop true lines)
+        | (OtherLine line) :: lines -> 
+            if inNotes then "</aside>"::line::(loop false lines)
+            else line::(loop false lines)
+        | _ -> []
+    text |> Array.toList |> loop false
 
 let preprocessing (text : string []) = 
     text 

--- a/tests/FsReveal.Tests/SpeakerNotesSpecs.fs
+++ b/tests/FsReveal.Tests/SpeakerNotesSpecs.fs
@@ -35,8 +35,10 @@ let expectedOutput = """<section >
 
 <p>Normal Text</p>
 
-<aside class="notes">Oh hey, these are some notes.</aside>
-<aside class="notes">And some more</aside>
+<aside class="notes">
+Oh hey, these are some notes.<br/>
+And some more<br/>
+</aside>
 
 </section>
 
@@ -56,6 +58,7 @@ let expectedOutput = """<section >
 
 
 """
+
 [<Test>]
 let ``can generate sections from markdown``() = 
     let presentation = FsReveal.GetPresentationFromMarkdown md


### PR DESCRIPTION
Generating single `<aside>` element for multi-line speaker notes #32 . Also added line breaks `<br/>`