### PR TITLE
Use optional parameters and allow speechifying FSI evaluator

### DIFF
--- a/src/FsReveal/AssemblyInfo.fs
+++ b/src/FsReveal/AssemblyInfo.fs
@@ -4,9 +4,9 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsReveal")>]
 [<assembly: AssemblyProductAttribute("FsReveal")>]
 [<assembly: AssemblyDescriptionAttribute("FsReveal parses markdown or F# script files and generates reveal.js slides.")>]
-[<assembly: AssemblyVersionAttribute("0.6.2")>]
-[<assembly: AssemblyFileVersionAttribute("0.6.2")>]
+[<assembly: AssemblyVersionAttribute("0.6.3")>]
+[<assembly: AssemblyFileVersionAttribute("0.6.3")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.6.2"
+    let [<Literal>] Version = "0.6.3"

--- a/src/FsReveal/FsReveal.fs
+++ b/src/FsReveal/FsReveal.fs
@@ -13,23 +13,13 @@ module FsRevealHelper =
     let mutable RevealJsFolder = __SOURCE_DIRECTORY__    
     let mutable TemplateFile = Path.Combine(__SOURCE_DIRECTORY__,"template.html")
 
-type FsReveal = 
-    static member GetPresentationFromScriptString(text : string) = 
-        normalizeLineBreaks(text).Split('\n') |> FsReveal.GetPresentationFromScriptLines
-    static member GetPresentationFromMarkdown(text : string) = 
-        normalizeLineBreaks(text).Split('\n') |> FsReveal.GetPresentationFromMarkdownLines
-    
-    static member GetPresentationFromScriptLines lines = 
-        let fsx = Formatting.preprocessing lines
-        let fsi = FsiEvaluator()
-        Literate.ParseScriptString(fsx, fsiEvaluator = fsi) |> getPresentation
-    
-    static member GetPresentationFromMarkdownLines lines = 
-        Formatting.preprocessing lines
-        |> Literate.ParseMarkdownString
-        |> getPresentation
-    
-    static member GenerateOutput outDir outFile presentation = 
+type FsReveal private() = 
+    static let defaultFileName (other:FileInfo) optInput = 
+        match optInput with 
+        | Some fn -> fn
+        | None -> other.Name.Replace(other.Extension, ".html")
+
+    static let generateOutput outDir outFile presentation = 
         if Directory.Exists outDir |> not then 
             Directory.CreateDirectory outDir |> ignore
             printfn "Creating %s.." outDir
@@ -43,29 +33,74 @@ type FsReveal =
         printfn "Apply template : %s" FsRevealHelper.TemplateFile
         let output = Formatting.GenerateHTML template presentation
         File.WriteAllText(outDir @@ outFile, output)
+
+    static let getPresentationFromScriptLines fsxFile fsiEvaluator lines = 
+        let fsx = Formatting.preprocessing lines
+        let fsi = match fsiEvaluator with None -> FsiEvaluator() :> IFsiEvaluator | Some fsi -> fsi
+        Literate.ParseScriptString(fsx, ?path=fsxFile, fsiEvaluator = fsi) |> getPresentation
     
-    static member private checkIfFileExistsAndRun file f = 
+    static let getPresentationFromMarkdownLines mdFile fsiEvaluator lines = 
+        let md = Formatting.preprocessing lines
+        let fsi = match fsiEvaluator with None -> FsiEvaluator() :> IFsiEvaluator | Some fsi -> fsi
+        Literate.ParseMarkdownString(md, ?path=mdFile, fsiEvaluator = fsi) |> getPresentation
+
+    static let checkIfFileExistsAndRun file f = 
         if File.Exists file then f()
         else printfn "%s does not exist. Abort!" file
+          
+    /// Creates a presentation from an F# Script file specified as string. This also evaluates
+    /// all F# code snippets in the presentation and embeds the outputs. If you do not specify
+    /// a custom FSI evaluator, a new default one is created. See `GenerateFromFile` for more info.
+    static member GetPresentationFromScriptString(text : string, ?fsxFile, ?fsiEvaluator) = 
+        normalizeLineBreaks(text).Split('\n')
+        |> getPresentationFromScriptLines fsxFile fsiEvaluator
+
+    /// Creates a presentation from a Markdown source file specified as string. This also evaluates
+    /// all F# code snippets in the presentation and embeds the outputs. If you do not specify
+    /// a custom FSI evaluator, a new default one is created. See `GenerateFromFile` for more info.
+    static member GetPresentationFromMarkdown(text : string, ?mdFile, ?fsiEvaluator) = 
+        normalizeLineBreaks(text).Split('\n')
+        |> getPresentationFromMarkdownLines mdFile fsiEvaluator
     
-    static member GenerateOutputFromScriptFile outDir outFile fsxFile = 
-        FsReveal.checkIfFileExistsAndRun fsxFile (fun () -> 
+    /// Write the specified presentation to a specified file in the output directory.
+    /// (if a file name is not specified, the default `index.html` will be used)
+    static member GenerateOutput(presentation, outDir, ?outFile) = 
+        generateOutput outDir (defaultArg outFile "index.html") presentation
+            
+    /// Processes a presentation specified as an F# Script. This also evaluates all 
+    /// F# code snippets in the presentation and embeds the outputs. If you do not specify
+    /// a custom FSI evaluator, a new default one is created. See `GenerateFromFile` for more info.
+    static member GenerateOutputFromScriptFile(fsxFile, outDir, ?outFile, ?fsiEvaluator) = 
+        checkIfFileExistsAndRun fsxFile (fun () -> 
             fsxFile
             |> File.ReadAllLines
-            |> FsReveal.GetPresentationFromScriptLines
-            |> FsReveal.GenerateOutput outDir outFile)
+            |> getPresentationFromScriptLines (Some fsxFile) fsiEvaluator
+            |> generateOutput outDir (defaultFileName (FileInfo fsxFile) outFile))
     
-    static member GenerateOutputFromMarkdownFile outDir outFile mdFile = 
-        FsReveal.checkIfFileExistsAndRun mdFile (fun () -> 
+    /// Processes a presentation specified as a Markdown. This also evaluates all 
+    /// F# code snippets in the presentation and embeds the outputs. If you do not specify
+    /// a custom FSI evaluator, a new default one is created. See `GenerateFromFile` for more info.
+    static member GenerateOutputFromMarkdownFile(mdFile, outDir, ?outFile, ?fsiEvaluator) = 
+        checkIfFileExistsAndRun mdFile (fun () -> 
             mdFile
             |> File.ReadAllLines
-            |> FsReveal.GetPresentationFromMarkdownLines
-            |> FsReveal.GenerateOutput outDir outFile)
+            |> getPresentationFromMarkdownLines  (Some mdFile) fsiEvaluator 
+            |> generateOutput outDir (defaultFileName (FileInfo mdFile) outFile))
     
-    static member GenerateFromFile outDir fileName = 
+    /// Processes a presentation specified as an F# Script file or a Markdown document. 
+    /// (When the file name has extension other than `fsx` or `md`, nothing happens).
+    ///
+    /// The method evaluates F# code snippets in the presentation and embeds the outputs. You
+    /// can specify a custom `fsiEvaluator` to add formatting for custom values and handle errors
+    /// during the valuation.  
+    ///
+    /// ## Parameters
+    /// - `fsiEvaluator` - Custom evaluator (you can use this parameter to add custom formatting
+    ///   that turns values into HTML when embedding them into the presentation)
+    static member GenerateFromFile(fileName, outDir, ?outFile, ?fsiEvaluator) = 
         let file = FileInfo fileName
-        let outputFileName = file.Name.Replace(file.Extension, ".html")
+        let outputFileName = defaultFileName file outFile
         match file.Extension with
-        | ".md" -> FsReveal.GenerateOutputFromMarkdownFile outDir outputFileName file.FullName
-        | ".fsx" -> FsReveal.GenerateOutputFromScriptFile outDir outputFileName file.FullName
+        | ".md" -> FsReveal.GenerateOutputFromMarkdownFile(file.FullName, outDir, outputFileName, ?fsiEvaluator=fsiEvaluator)
+        | ".fsx" -> FsReveal.GenerateOutputFromScriptFile(file.FullName, outDir, outputFileName, ?fsiEvaluator=fsiEvaluator)
         | _ -> ()

--- a/tests/FsReveal.Tests/FsRevealIntroTest.fs
+++ b/tests/FsReveal.Tests/FsRevealIntroTest.fs
@@ -6,15 +6,15 @@ open FsUnit
 
 [<Test>]
 let ``can read FsReveal intro``() = 
-    let doc = FsReveal.GenerateOutputFromMarkdownFile "." "index.html" "Index.md" 
+    let doc = FsReveal.GenerateOutputFromMarkdownFile("Index.md", "." ,"index.html")
 
     System.IO.File.Exists "index.html" |> shouldEqual true
 
 
 [<Test>]
 let ``can create intro twice``() = 
-    let doc = FsReveal.GenerateOutputFromMarkdownFile "." "index.html" "Index.md" 
-    let doc = FsReveal.GenerateOutputFromMarkdownFile "." "sample.html" "Index.md" 
+    let doc = FsReveal.GenerateOutputFromMarkdownFile("Index.md", ".", "index.html") 
+    let doc = FsReveal.GenerateOutputFromMarkdownFile("Index.md", ".", "sample.html")
 
     System.IO.File.Exists "index.html" |> shouldEqual true
     System.IO.File.Exists "sample.html" |> shouldEqual true


### PR DESCRIPTION
In my LambdaDays talk, I used evaluation of F# snippets to create simple diagrams as inline F# snippets - see [the code](https://github.com/tpetricek/Talks/blob/master/2015/literate-programming/slides/sample.fsx#L319). The way this works is that the snippet returns a value of a custom type and then the FSI evaluator turns it into HTML.

To do this, I need to pass custom `IFsiEvaluator` to FsReveal (the evaluator is configured with formatters).

This PR makes it possible to pass custom evaluator. The current API does not make it possible to add optional parameters, so sadly this probably has to be a breaking change. This PR changes the API to use tuples style parameters and it makes some of them optional.

If people have better ideas on how to handle configuration, then please suggest alternative ways for specifying the parameters - but I guess it would be good to find some mechanism that will avoid breaking changes if we want to add more options in the future.