### PR TITLE
Use optional parameters and allow speechifying FSI evaluator (2.)

### DIFF
--- a/docs/tools/createSlides.fsx
+++ b/docs/tools/createSlides.fsx
@@ -1,6 +1,6 @@
 #I @"../../bin/"
 #r "FsReveal.dll"
-
+#r "FSharp.Literate.dll"
 #r "../../packages/FAKE/tools/FakeLib.dll"
 open Fake
 open System.IO
@@ -36,7 +36,7 @@ let generateFor (file:FileInfo) =
         copyPics()
         let rec tryGenerate trials =
             try
-                FsReveal.GenerateFromFile outDir file.FullName                
+                FsReveal.GenerateFromFile(file.FullName, outDir)
             with 
             | exn when trials > 0 -> tryGenerate (trials - 1)
             | exn -> 

--- a/src/FsReveal/AssemblyInfo.fs
+++ b/src/FsReveal/AssemblyInfo.fs
@@ -4,9 +4,9 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsReveal")>]
 [<assembly: AssemblyProductAttribute("FsReveal")>]
 [<assembly: AssemblyDescriptionAttribute("FsReveal parses markdown or F# script files and generates reveal.js slides.")>]
-[<assembly: AssemblyVersionAttribute("0.6.2")>]
-[<assembly: AssemblyFileVersionAttribute("0.6.2")>]
+[<assembly: AssemblyVersionAttribute("0.6.3")>]
+[<assembly: AssemblyFileVersionAttribute("0.6.3")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.6.2"
+    let [<Literal>] Version = "0.6.3"

--- a/src/FsReveal/FsReveal.fs
+++ b/src/FsReveal/FsReveal.fs
@@ -13,23 +13,13 @@ module FsRevealHelper =
     let mutable RevealJsFolder = __SOURCE_DIRECTORY__    
     let mutable TemplateFile = Path.Combine(__SOURCE_DIRECTORY__,"template.html")
 
-type FsReveal = 
-    static member GetPresentationFromScriptString(text : string) = 
-        normalizeLineBreaks(text).Split('\n') |> FsReveal.GetPresentationFromScriptLines
-    static member GetPresentationFromMarkdown(text : string) = 
-        normalizeLineBreaks(text).Split('\n') |> FsReveal.GetPresentationFromMarkdownLines
-    
-    static member GetPresentationFromScriptLines lines = 
-        let fsx = Formatting.preprocessing lines
-        let fsi = FsiEvaluator()
-        Literate.ParseScriptString(fsx, fsiEvaluator = fsi) |> getPresentation
-    
-    static member GetPresentationFromMarkdownLines lines = 
-        Formatting.preprocessing lines
-        |> Literate.ParseMarkdownString
-        |> getPresentation
-    
-    static member GenerateOutput outDir outFile presentation = 
+type FsReveal private() = 
+    static let defaultFileName (other:FileInfo) optInput = 
+        match optInput with 
+        | Some fn -> fn
+        | None -> other.Name.Replace(other.Extension, ".html")
+
+    static let generateOutput outDir outFile presentation = 
         if Directory.Exists outDir |> not then 
             Directory.CreateDirectory outDir |> ignore
             printfn "Creating %s.." outDir
@@ -59,25 +49,60 @@ type FsReveal =
     static let checkIfFileExistsAndRun file f = 
         if File.Exists file then f()
         else printfn "%s does not exist. Abort!" file
+          
+    /// Creates a presentation from an F# Script file specified as string. This also evaluates
+    /// all F# code snippets in the presentation and embeds the outputs. If you do not specify
+    /// a custom FSI evaluator, a new default one is created. See `GenerateFromFile` for more info.
+    static member GetPresentationFromScriptString(text : string, ?fsxFile, ?fsiEvaluator) = 
+        normalizeLineBreaks(text).Split('\n')
+        |> getPresentationFromScriptLines fsxFile fsiEvaluator
+
+    /// Creates a presentation from a Markdown source file specified as string. This also evaluates
+    /// all F# code snippets in the presentation and embeds the outputs. If you do not specify
+    /// a custom FSI evaluator, a new default one is created. See `GenerateFromFile` for more info.
+    static member GetPresentationFromMarkdown(text : string, ?mdFile, ?fsiEvaluator) = 
+        normalizeLineBreaks(text).Split('\n')
+        |> getPresentationFromMarkdownLines mdFile fsiEvaluator
     
-    static member GenerateOutputFromScriptFile outDir outFile fsxFile = 
-        FsReveal.checkIfFileExistsAndRun fsxFile (fun () -> 
+    /// Write the specified presentation to a specified file in the output directory.
+    /// (if a file name is not specified, the default `index.html` will be used)
+    static member GenerateOutput(presentation, outDir, ?outFile) = 
+        generateOutput outDir (defaultArg outFile "index.html") presentation
+            
+    /// Processes a presentation specified as an F# Script. This also evaluates all 
+    /// F# code snippets in the presentation and embeds the outputs. If you do not specify
+    /// a custom FSI evaluator, a new default one is created. See `GenerateFromFile` for more info.
+    static member GenerateOutputFromScriptFile(fsxFile, outDir, ?outFile, ?fsiEvaluator) = 
+        checkIfFileExistsAndRun fsxFile (fun () -> 
             fsxFile
             |> File.ReadAllLines
-            |> FsReveal.GetPresentationFromScriptLines
-            |> FsReveal.GenerateOutput outDir outFile)
+            |> getPresentationFromScriptLines (Some fsxFile) fsiEvaluator
+            |> generateOutput outDir (defaultFileName (FileInfo fsxFile) outFile))
     
-    static member GenerateOutputFromMarkdownFile outDir outFile mdFile = 
-        FsReveal.checkIfFileExistsAndRun mdFile (fun () -> 
+    /// Processes a presentation specified as a Markdown. This also evaluates all 
+    /// F# code snippets in the presentation and embeds the outputs. If you do not specify
+    /// a custom FSI evaluator, a new default one is created. See `GenerateFromFile` for more info.
+    static member GenerateOutputFromMarkdownFile(mdFile, outDir, ?outFile, ?fsiEvaluator) = 
+        checkIfFileExistsAndRun mdFile (fun () -> 
             mdFile
             |> File.ReadAllLines
-            |> FsReveal.GetPresentationFromMarkdownLines
-            |> FsReveal.GenerateOutput outDir outFile)
+            |> getPresentationFromMarkdownLines  (Some mdFile) fsiEvaluator 
+            |> generateOutput outDir (defaultFileName (FileInfo mdFile) outFile))
     
-    static member GenerateFromFile outDir fileName = 
+    /// Processes a presentation specified as an F# Script file or a Markdown document. 
+    /// (When the file name has extension other than `fsx` or `md`, nothing happens).
+    ///
+    /// The method evaluates F# code snippets in the presentation and embeds the outputs. You
+    /// can specify a custom `fsiEvaluator` to add formatting for custom values and handle errors
+    /// during the valuation.  
+    ///
+    /// ## Parameters
+    /// - `fsiEvaluator` - Custom evaluator (you can use this parameter to add custom formatting
+    ///   that turns values into HTML when embedding them into the presentation)
+    static member GenerateFromFile(fileName, outDir, ?outFile, ?fsiEvaluator) = 
         let file = FileInfo fileName
-        let outputFileName = file.Name.Replace(file.Extension, ".html")
+        let outputFileName = defaultFileName file outFile
         match file.Extension with
-        | ".md" -> FsReveal.GenerateOutputFromMarkdownFile outDir outputFileName file.FullName
-        | ".fsx" -> FsReveal.GenerateOutputFromScriptFile outDir outputFileName file.FullName
+        | ".md" -> FsReveal.GenerateOutputFromMarkdownFile(file.FullName, outDir, outputFileName, ?fsiEvaluator=fsiEvaluator)
+        | ".fsx" -> FsReveal.GenerateOutputFromScriptFile(file.FullName, outDir, outputFileName, ?fsiEvaluator=fsiEvaluator)
         | _ -> ()

--- a/src/FsReveal/FsReveal.fs
+++ b/src/FsReveal/FsReveal.fs
@@ -37,12 +37,14 @@ type FsReveal private() =
     static let getPresentationFromScriptLines fsxFile fsiEvaluator lines = 
         let fsx = Formatting.preprocessing lines
         let fsi = match fsiEvaluator with None -> FsiEvaluator() :> IFsiEvaluator | Some fsi -> fsi
-        Literate.ParseScriptString(fsx, ?path=fsxFile, fsiEvaluator = fsi) |> getPresentation
+        Literate.ParseScriptString(fsx, ?path=Option.map Path.GetFullPath fsxFile, fsiEvaluator = fsi) 
+        |> getPresentation
     
     static let getPresentationFromMarkdownLines mdFile fsiEvaluator lines = 
         let md = Formatting.preprocessing lines
         let fsi = match fsiEvaluator with None -> FsiEvaluator() :> IFsiEvaluator | Some fsi -> fsi
-        Literate.ParseMarkdownString(md, ?path=mdFile, fsiEvaluator = fsi) |> getPresentation
+        Literate.ParseMarkdownString(md, ?path=Option.map Path.GetFullPath mdFile, fsiEvaluator = fsi) 
+        |> getPresentation
 
     static let checkIfFileExistsAndRun file f = 
         if File.Exists file then f()

--- a/tests/FsReveal.Tests/FsReveal.Tests.fsproj
+++ b/tests/FsReveal.Tests/FsReveal.Tests.fsproj
@@ -79,9 +79,13 @@
     <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="FSharp.Compiler.Interactive.Settings">
+      <HintPath>..\..\lib\FSharp.Compiler.Interactive.Settings.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/tests/FsReveal.Tests/FsRevealIntroTest.fs
+++ b/tests/FsReveal.Tests/FsRevealIntroTest.fs
@@ -6,15 +6,15 @@ open FsUnit
 
 [<Test>]
 let ``can read FsReveal intro``() = 
-    let doc = FsReveal.GenerateOutputFromMarkdownFile "." "index.html" "Index.md" 
+    let doc = FsReveal.GenerateOutputFromMarkdownFile("Index.md", "." ,"index.html")
 
     System.IO.File.Exists "index.html" |> shouldEqual true
 
 
 [<Test>]
 let ``can create intro twice``() = 
-    let doc = FsReveal.GenerateOutputFromMarkdownFile "." "index.html" "Index.md" 
-    let doc = FsReveal.GenerateOutputFromMarkdownFile "." "sample.html" "Index.md" 
+    let doc = FsReveal.GenerateOutputFromMarkdownFile("Index.md", ".", "index.html") 
+    let doc = FsReveal.GenerateOutputFromMarkdownFile("Index.md", ".", "sample.html")
 
     System.IO.File.Exists "index.html" |> shouldEqual true
     System.IO.File.Exists "sample.html" |> shouldEqual true


### PR DESCRIPTION
This is a corrected version of #51.

The issue was that test runner couldn't find `FSharp.Compiler.Interactive.Settings.dll` (which FCS currently requires) and that it was not able to load `FSharp.Core.dll` (looks like the file was locked, or something). The first is fixed by adding reference with CopyLocal=true and the other is fixed by changing CopyLocal to false for FSharp.Core.dll (this is a bit odd, but I had the same issue in F# Formatting).

Tests now run fine on my machine!