### PR TITLE
Do not automatically create evaluator

### DIFF
--- a/src/FsReveal/FsReveal.fs
+++ b/src/FsReveal/FsReveal.fs
@@ -36,14 +36,12 @@ type FsReveal private() =
 
     static let getPresentationFromScriptLines fsxFile fsiEvaluator lines = 
         let fsx = Formatting.preprocessing lines
-        let fsi = match fsiEvaluator with None -> FsiEvaluator() :> IFsiEvaluator | Some fsi -> fsi
-        Literate.ParseScriptString(fsx, ?path=Option.map Path.GetFullPath fsxFile, fsiEvaluator = fsi) 
+        Literate.ParseScriptString(fsx, ?path=Option.map Path.GetFullPath fsxFile, ?fsiEvaluator = fsiEvaluator) 
         |> getPresentation
     
     static let getPresentationFromMarkdownLines mdFile fsiEvaluator lines = 
         let md = Formatting.preprocessing lines
-        let fsi = match fsiEvaluator with None -> FsiEvaluator() :> IFsiEvaluator | Some fsi -> fsi
-        Literate.ParseMarkdownString(md, ?path=Option.map Path.GetFullPath mdFile, fsiEvaluator = fsi) 
+        Literate.ParseMarkdownString(md, ?path=Option.map Path.GetFullPath mdFile, ?fsiEvaluator = fsiEvaluator) 
         |> getPresentation
 
     static let checkIfFileExistsAndRun file f = 


### PR DESCRIPTION
I think it makes sense to do this change (proposed by @forki earlier).

Creating the evaluator automatically is nice when there is no way to specify it - but if we create it automatically, then there is no way to turn it off (if you don't want it). Also, the latest change in "master" always provides an evaluator, so the behavior there will be the same.

(A separate issue is to add tests for the evaluator that work with all testing frameworks.)