### PR TITLE
Copy subfolders for images, fixes #61

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -45,8 +45,7 @@ let copyStylesheet() =
 
 let copyPics() =
     try
-      !! (slidesDir @@ "images/*.*")
-      |> CopyFiles (outDir @@ "images")
+      CopyDir (outDir @@ "images") (slidesDir @@ "images") (fun f -> true)
     with
     | exn -> traceImportant <| sprintf "Could not copy picture: %s" exn.Message    
 


### PR DESCRIPTION
Currently this codes copies the images:

```
!! (slidesDir @@ "images/*.*")
|> CopyFiles (outDir @@ "images")
```
Basicly it says: take all files in the direct root of ```images``` and copy them, ignoring subfolders.

I propose to copy the entire images directory:

```CopyDir (outDir @@ "images") (slidesDir @@ "images") (fun f -> true)```

This allows people to either keep using it as it is now, directly in the root. But also allows you to organise your images.

Fixes #61