### PR TITLE
Reveal.js fork to get highlight.js v8.6

### DIFF
--- a/docs/tools/createSlides.fsx
+++ b/docs/tools/createSlides.fsx
@@ -10,7 +10,7 @@ open FsReveal
 let root = Path.Combine(__SOURCE_DIRECTORY__,"../../")
 let slidesDir = root @@ "/docs/slides"
 let outDir = root @@ "/docs/output/samples/"
-FsReveal.FsRevealHelper.RevealJsFolder <- Path.Combine(root,"paket-files/hakimel/reveal.js")
+FsReveal.FsRevealHelper.RevealJsFolder <- Path.Combine(root,"paket-files/kfuglsang/reveal.js")
 FsReveal.FsRevealHelper.TemplateFile <- Path.Combine(root,"src/FsReveal/template.html")
 
 let targetFCIS = Path.Combine(root,@"packages/FAKE/tools/FSharp.Compiler.Interactive.Settings.dll")

--- a/nuget/paket.template
+++ b/nuget/paket.template
@@ -12,7 +12,7 @@ tags
 files
     ../bin/FsReveal.* ==> lib/net40
     ../bin/FSharp.Compiler.Interactive.Settings.dll ==> lib/net40
-    ../paket-files/hakimel/reveal.js/**/*.* ==> reveal.js
+    ../paket-files/kfuglsang/reveal.js/**/*.* ==> reveal.js
     ../src/FsReveal/style.css ==> reveal.js/fsharp.formatting/styles
     ../src/FsReveal/tips.js ==> reveal.js/fsharp.formatting/styles
     ../src/FsReveal/deedle.css ==> reveal.js/fsharp.formatting/styles

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,6 +6,6 @@ nuget FSharp.Formatting
 nuget NUnit 
 nuget NUnit.Runners
 
-github hakimel/reveal.js:3.1.0
+github kfuglsang/reveal.js:highlightjs-86
 github forki/FsUnit FsUnit.fs
 github fsharp/FAKE modules/Octokit/Octokit.fsx

--- a/paket.lock
+++ b/paket.lock
@@ -1,7 +1,7 @@
 NUGET
   remote: https://nuget.org/api/v2
   specs:
-    FAKE (3.34.6)
+    FAKE (3.34.7)
     FSharp.Compiler.Service (0.0.89)
     FSharp.Formatting (2.9.6)
       FSharp.Compiler.Service (>= 0.0.87)
@@ -20,13 +20,13 @@ NUGET
       Microsoft.Net.Http
     SourceLink.Fake (0.5.0)
 GITHUB
-  remote: hakimel/reveal.js
+  remote: kfuglsang/reveal.js
   specs:
-    FULLPROJECT (eff2265bbd6d892ae2316edff748754b4b0c4798)
+    FULLPROJECT (0563835fc00ce2c255cad0e4a089f559cdd48964)
   remote: forki/FsUnit
   specs:
     FsUnit.fs (81d27fd09575a32c4ed52eadb2eeac5f365b8348)
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (3b94085dde8f945057fd1f94312f3d64d54cfbdf)
+    modules/Octokit/Octokit.fsx (83f137969eb0ad8656426b2998bea5227a7bcc27)
       Octokit


### PR DESCRIPTION
I created a fork of reveal.js that this PR refers to rather than hakimel's original.
This will let FsReveal grab highlight.js version 8.6 that, amongst others, includes support for the C/AL language.