### PR TITLE
Capitalization for linux compatibility

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -3,7 +3,7 @@
 #I @"packages/Suave/lib/net40"
 
 #r "FakeLib.dll"
-#r "suave.dll"
+#r "Suave.dll"
 
 #load "fsreveal.fsx"
 


### PR DESCRIPTION
Changing "suave.dll" to capital S because linux is case sensitive.