### PR TITLE
Fix #96: ugly tooltip flickering when cursor overlaps parent element

### DIFF
--- a/src/FsReveal/style.css
+++ b/src/FsReveal/style.css
@@ -1,7 +1,7 @@
 @import url(https://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans+Mono|Open+Sans:400,600,700);
 
-/*-------------------------------------------------------------------------- 
-  Formatting for F# code snippets 
+/*--------------------------------------------------------------------------
+  Formatting for F# code snippets
 /*--------------------------------------------------------------------------*/
 
 /* strings --- and stlyes for other string related formats */
@@ -40,27 +40,27 @@ span.prep { color:#af75c1; }
 span.fsi { color:#808080; }
 
 /* omitted */
-span.omitted { 
-	background:#3c4e52;
+span.omitted {
+  background:#3c4e52;
   border-radius:5px;
-	color:#808080;
-	padding:0px 0px 1px 0px;
+  color:#808080;
+  padding:0px 0px 1px 0px;
 }
 /* tool tip */
 div.tip {
-	background:#475b5f;
-    border-radius:4px;
-    font:16pt 'Droid Sans', arial, sans-serif;
-	padding:6px 8px 6px 8px;
-	display:none;
-    color:#d1d1d1;
-    z-index: 2;
+  background:#475b5f;
+  border-radius:4px;
+  font:16pt 'Droid Sans', arial, sans-serif;
+  padding:6px 8px 6px 8px;
+  display:none;
+  color:#d1d1d1;
+  z-index: 2;
 }
 table.pre pre {
   padding:0px;
   margin:0px;
   border:none;
-} 
+}
 table.pre, pre.fssnip, pre {
   line-height:13pt;
   border:1px solid #d8d8d8;
@@ -72,7 +72,7 @@ table.pre, pre.fssnip, pre {
   background-color:#212d30;
   padding:10px;
   border-radius:5px;
-  color:#d1d1d1;  
+  color:#d1d1d1;
 }
 table.pre pre {
   padding:0px;
@@ -89,7 +89,7 @@ table.pre td.lines {
   width:30px;
 }
 
-/*-------------------------------------------------------------------------- 
+/*--------------------------------------------------------------------------
   Formatting for page & standard document content
 /*--------------------------------------------------------------------------*/
 
@@ -100,7 +100,7 @@ body {
 }
 
 pre {
-    word-wrap: inherit;
+  word-wrap: inherit;
 }
 
 /* Format the heading - nicer spacing etc. */
@@ -157,7 +157,7 @@ td.title, thead {
 #main li { font-size: 11pt; margin: 5px 0px 5px 0px; }
 #main strong { font-weight:700; }
 
-/*-------------------------------------------------------------------------- 
+/*--------------------------------------------------------------------------
   Formatting for API reference
 /*--------------------------------------------------------------------------*/
 
@@ -189,8 +189,8 @@ td.title, thead {
 .github-link .normal { display: block; }
 .github-link:hover .normal { display: none; }
 
-/*-------------------------------------------------------------------------- 
-  Links 
+/*--------------------------------------------------------------------------
+  Links
 /*--------------------------------------------------------------------------*/
 
 h1 a, h1 a:hover, h1 a:focus,
@@ -200,14 +200,14 @@ h4 a, h4 a:hover, h4 a:focus,
 h5 a, h5 a:hover, h5 a:focus,
 h6 a, h6 a:hover, h6 a:focus { color : inherit; text-decoration : inherit; outline:none }
 
-/*-------------------------------------------------------------------------- 
-  Additional formatting for the homepage 
+/*--------------------------------------------------------------------------
+  Additional formatting for the homepage
 /*--------------------------------------------------------------------------*/
 
-#nuget { 
+#nuget {
   margin-top:20px;
-  font-size: 11pt; 
-  padding:20px; 
+  font-size: 11pt;
+  padding:20px;
 }
 
 #nuget pre {

--- a/src/FsReveal/style.css
+++ b/src/FsReveal/style.css
@@ -55,6 +55,7 @@ div.tip {
   display:none;
   color:#d1d1d1;
   z-index: 2;
+  pointer-events:none;
 }
 table.pre pre {
   padding:0px;


### PR DESCRIPTION
See #96 for details of the bug.

Note that this PR has two commits, one of which is just a whitespace change because the mixing of tabs and spaces in `style.css` was bugging me. If you prefer not to merge whitespace-change-only commits, let me know and I'll make a new PR without that commit.