### PR TITLE
Position tooltips properly on all screens

### DIFF
--- a/src/FsReveal/tips.js
+++ b/src/FsReveal/tips.js
@@ -7,21 +7,6 @@ function hideTip(evt, name, unique) {
     currentTip = null;
 }
 
-function findPos(obj) {
-    // no idea why, but it behaves differently in webbrowser component
-    if (window.location.search == "?inapp")
-        return [obj.offsetLeft + 10, obj.offsetTop + 30];
-
-    var curleft = 0;
-    var curtop = obj.offsetHeight;
-    while (obj) {
-        curleft += obj.offsetLeft;
-        curtop += obj.offsetTop;
-        obj = obj.offsetParent;
-    };
-    return [curleft, curtop];
-}
-
 function hideUsingEsc(e) {
     if (!e) { e = event; }
     hideTip(e, currentTipElement, currentTip);
@@ -33,14 +18,15 @@ function showTip(evt, name, unique, owner) {
     currentTip = unique;
     currentTipElement = name;
 
-    var pos = findPos(owner ? owner : (evt.srcElement ? evt.srcElement : evt.target));
-    var posx = pos[0];
-    var posy = pos[1];
+    var target = owner ? owner : (evt.srcElement ? evt.srcElement : evt.target);
+    var posx = target.offsetLeft;
+    var posy = target.offsetTop + target.offsetHeight;
 
     var el = document.getElementById(name);
-    var parent = (document.documentElement == null) ? document.body : document.documentElement;
+    var parent = target.offsetParent;
     el.style.position = "absolute";
     el.style.left = posx + "px";
     el.style.top = posy + "px";
+    parent.appendChild(el);
     el.style.display = "block";
 }


### PR DESCRIPTION
The reveal.js animated slide transitions are done with 3D transforms, which throws off the element-positioning logic from FSharp.Formatting since it assumes a "normal" Web page. Under reveal.js, tooltips should be positioned as a sibling of the element they belong with. Then their positioning will be correct no matter what 3D transform is in effect.

Fixes #71.