### PR TITLE
Update template.html

### DIFF
--- a/src/FsReveal/template.html
+++ b/src/FsReveal/template.html
@@ -11,7 +11,7 @@
     <script src="//code.jquery.com/jquery-1.8.0.js"></script>
     <script src="//code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
     <script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
     <link rel="stylesheet" href="css/reveal.css">
     <link rel="stylesheet" href="css/theme/{theme}.css" id="theme">


### PR DESCRIPTION
replacing mathjax CDN - see [CDN shutting down](https://www.mathjax.org/cdn-shutting-down/)